### PR TITLE
also for linux too

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -234,6 +234,7 @@ You need to use clang and libc++ to compile Aseprite:
       -DSKIA_DIR=$HOME/deps/skia \
       -DSKIA_LIBRARY_DIR=$HOME/deps/skia/out/Release-x64 \
       -DSKIA_LIBRARY=$HOME/deps/skia/out/Release-x64/libskia.a \
+      -DWEBP_LIBRARIES=$HOME/deps/skia/out/Release-x64/libwebp.a \
       -G Ninja \
       ..
     ninja aseprite


### PR DESCRIPTION
Getting the source code from `https://github.com/aseprite/aseprite/releases` (mine is 1.3.7), extracted to `/home/bang1338/aseprite`

Compile with this command (like in [INSTALL.md](https://github.com/aseprite/aseprite/blob/main/INSTALL.md) mentioned):
```sh
cd aseprite
mkdir build
cd build
export CC=clang
export CXX=clang++
cmake \
  -DCMAKE_BUILD_TYPE=RelWithDebInfo \
  -DCMAKE_CXX_FLAGS:STRING=-stdlib=libc++ \
  -DCMAKE_EXE_LINKER_FLAGS:STRING=-stdlib=libc++ \
  -DLAF_BACKEND=skia \
  -DSKIA_DIR=$HOME/deps/skia \
  -DSKIA_LIBRARY_DIR=$HOME/deps/skia/out/Release-x64 \
  -DSKIA_LIBRARY=$HOME/deps/skia/out/Release-x64/libskia.a \
  -G Ninja \
  ..
ninja aseprite
```

Error (some part trimmed by using "..."):
```
-- aseprite libwebp: WEBP_LIBRARIES-NOTFOUND
...
-- Configuring done
CMake Error: The following variables are used in this project, but they are set to NOTFOUND.
Please set them or make sure they are set and tested correctly in the CMake files:
WEBP_LIBRARIES

...

CMake Generate step failed.  Build files cannot be regenerated correctly.
ninja: error: loading 'build.ninja': No such file or directory
```

This issues mentioned in: #3628, #3831, #4255 (and likely more)

This is because CMake can't find `WEBP_LIBRARIES` for Skia

Here's my fix. In my case, I used `Release-x64` of Skia:

```sh
cd aseprite
mkdir build
cd build
export CC=clang
export CXX=clang++
cmake \
  -DCMAKE_BUILD_TYPE=RelWithDebInfo \
  -DCMAKE_CXX_FLAGS:STRING=-stdlib=libc++ \
  -DCMAKE_EXE_LINKER_FLAGS:STRING=-stdlib=libc++ \
  -DLAF_BACKEND=skia \
  -DSKIA_DIR=$HOME/deps/skia \
  -DSKIA_LIBRARY_DIR=$HOME/deps/skia/out/Release-x64 \
  -DSKIA_LIBRARY=$HOME/deps/skia/out/Release-x64/libskia.a \
  -DWEBP_LIBRARIES=$HOME/deps/skia/out/Release-x64/libwebp.a \
  -G Ninja \
  ..
ninja aseprite
```

Confirmed CMake working and `build.ninja` generated. ![image](https://github.com/aseprite/aseprite/assets/75790567/dfeadea5-a0a4-44f6-9115-acd8e2e12570)

Extra Edit (August 15th 2024):

A pull request #4587 mentioned a libwebp. I'm not tested yet, but looks like this is for libwebp, not Skia's webp.

* Aseprite version: 1.3.7-dev
* Platform: Linux

Edited in August 15th 2024 as [emadgit's request](https://github.com/aseprite/aseprite/pull/4529#issuecomment-2275769826).

<!-- Please read the contribution guidelines before submitting a pull request. -->
<!-- By submitting this pull request, you agree that your contributions are
     licensed under the Individual Contributor License Agreement V4.0. -->
<!-- If you're a first-time contributor, please sign the CLA
     as indicated in https://github.com/igarastudio/cla#signing
     and acknowledge it by leaving the statement below. -->

I agree that my contributions are licensed under the Individual Contributor License Agreement V4.0 ("CLA") as stated in https://github.com/igarastudio/cla/blob/main/cla.md

I have signed the CLA following the steps given in https://github.com/igarastudio/cla#signing
